### PR TITLE
Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ A common issue with non-standard monitor sizes (for the year 2011 :) ) is that t
 
 By default, this is now set to your current monitor's resolution, which prevents these sorts of issues in the first place.
 
-## Installation
+## Windows Installation
 
 Installing the patch is very simple:
 
@@ -119,6 +119,19 @@ Installing the patch is very simple:
 3. Place dinput8.dll into the game folder (same location as LaNoire.exe)
 
 Done. No special setup required. 
+
+## Linux (Lutrs & Steam Proton) Installation:
+
+Same as above except requires winecfg to override/accept the dinput8 dll. 
+
+1. Copy the extracted dinput8.dll into your game's folder (same as above, where LaNoire.exe is located).
+2. If you are using Lutris => (I assume you have L.A. Noire setup in Lutris already), click on the Wine icon -> Winetricks. Proceed with Step 5.
+3. If you are using Steam  => Run `protontricks --gui` in a terminal (you may have to install protontricks from your distro's repo. Consult your package manager.
+4. Select 'L.A. Noire 110800' and wait until a window pops-up (As long as the terminal says 'Executing mkdir' wait. It may show an error regarding 64-bit/32-Bit Prefix, but it'll take a while. Just click on 'Ok'. 
+5. Select 'Run winecfg' (if you don't see that option, open 'Install an application' and cancel out. Now winecfg should be visible.
+6. Select the 'Libraries' tab and add 'dinput8.dll' from the 'New override for library' dropdown menu.
+
+If 'dinput8(native, builtin)' is visible in the list, then you've successfully installed the patch on Linux.
 
 ## Supported versions
 


### PR DESCRIPTION
Added installation steps for Lutris and Steam Proton on Linux, as well as added the word 'Windows' to the previous Installation title for a more accurate seperation.
I can confirm that with the provided steps, the patch is now working fully under Linux.
![Screenshot_20220223_013554](https://user-images.githubusercontent.com/45468984/155243770-2a23613e-e534-49c4-98d2-a6df209d697b.png)

    Propersal: Adding crucial installation information for Linux users to apply the patch properly (in regards to dll override).
    Replaced line 113 String from "Installation to "Windows Installation".
    Added lines 123-134 Linux installation steps.