### PR TITLE
Fixed memory leak.

### DIFF
--- a/dinput8/lanPatch.h
+++ b/dinput8/lanPatch.h
@@ -116,7 +116,7 @@ private:
 
 	inline static bool NopInstruction(unsigned long addr, unsigned long nopSize)
 	{
-		char* nop = new char[nopSize];
+		char nop[16];
 		memset(nop, 0x90, nopSize);
 		return WriteMemory(addr, nop, nopSize, true);
 	}


### PR DESCRIPTION
The function _NopInstruction_ leaked memory. The maximum nopSize used in the patch is 14 bytes, thus I set a static 16B char array on stack rather than allocating this instruction data on the heap.